### PR TITLE
feat: add meeting minutes feature - prompt templates and hook

### DIFF
--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -1,0 +1,136 @@
+import { useState, useCallback } from 'react';
+import useChatApi from './useChatApi';
+import useModel from './useModel';
+import { getPrompter } from '../prompts';
+import { BaseMessage, Content, Model } from 'generative-ai-use-cases-jp';
+import { produce } from 'immer';
+
+export type MeetingMinutesStyle =
+  | 'standard'
+  | 'executive'
+  | 'detailed'
+  | 'custom';
+
+export const useMeetingMinutes = () => {
+  const { predictStream } = useChatApi();
+  const { modelIds: availableModels, textModels } = useModel();
+
+  // Meeting minutes specific state
+  const [minutesStyle, setMinutesStyle] =
+    useState<MeetingMinutesStyle>('standard');
+  const [autoGenerate, setAutoGenerate] = useState(false);
+  const [generationFrequency, setGenerationFrequency] = useState(5); // in minutes
+  const [generatedMinutes, setGeneratedMinutes] = useState('');
+  const [lastProcessedTranscript, setLastProcessedTranscript] = useState('');
+  const [lastGeneratedTime, setLastGeneratedTime] = useState<Date | null>(null);
+  const [customPrompt, setCustomPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const generateMinutes = useCallback(
+    async (
+      transcript: string,
+      modelId: string,
+      onGenerate?: (
+        status: 'generating' | 'success' | 'error',
+        data?: { message?: string; minutes?: string }
+      ) => void
+    ) => {
+      if (!transcript || transcript.trim() === '') return;
+
+      const model = textModels.find((m) => m.modelId === modelId);
+      if (!model) {
+        console.error('Model not found:', modelId);
+        onGenerate?.('error', { message: 'Model not found' });
+        return;
+      }
+
+      setLoading(true);
+      onGenerate?.('generating');
+
+      try {
+        const prompter = getPrompter(model);
+
+        const promptContent =
+          minutesStyle === 'custom' && customPrompt
+            ? customPrompt
+            : prompter.meetingMinutesPrompt({
+                transcript,
+                format: minutesStyle as 'standard' | 'executive' | 'detailed',
+              });
+
+        const messages: BaseMessage[] = [
+          {
+            role: 'user',
+            content: [
+              {
+                contentType: 'text',
+                body: promptContent,
+              },
+            ] as Content[],
+          },
+        ];
+
+        const stream = predictStream({
+          model: model as Model,
+          messages,
+        });
+
+        let fullResponse = '';
+        setGeneratedMinutes('');
+
+        for await (const chunk of stream) {
+          if (chunk) {
+            fullResponse += chunk;
+            setGeneratedMinutes(produce((draft) => draft + chunk));
+          }
+        }
+
+        setLastProcessedTranscript(transcript);
+        setLastGeneratedTime(new Date());
+        onGenerate?.('success', { minutes: fullResponse });
+      } catch (error) {
+        console.error('Error generating minutes:', error);
+        onGenerate?.('error', {
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [minutesStyle, customPrompt, predictStream, textModels]
+  );
+
+  const clearMinutes = useCallback(() => {
+    setGeneratedMinutes('');
+    setLastProcessedTranscript('');
+    setLastGeneratedTime(null);
+  }, []);
+
+  return {
+    // State
+    minutesStyle,
+    setMinutesStyle,
+    autoGenerate,
+    setAutoGenerate,
+    generationFrequency,
+    setGenerationFrequency,
+    generatedMinutes,
+    setGeneratedMinutes,
+    lastProcessedTranscript,
+    setLastProcessedTranscript,
+    lastGeneratedTime,
+    setLastGeneratedTime,
+    customPrompt,
+    setCustomPrompt,
+    loading,
+
+    // Actions
+    generateMinutes,
+    clearMinutes,
+
+    // Utilities
+    availableModels,
+  };
+};
+
+export default useMeetingMinutes;

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -11,6 +11,7 @@ import {
   VideoAnalyzerParams,
   WebContentParams,
   DiagramParams,
+  MeetingMinutesParams,
 } from './index';
 
 import {
@@ -555,6 +556,54 @@ Output only the selected chart type from the <Choice> list, with an exact match,
         diagramSystemPrompts[params.diagramType!] ||
         diagramSystemPrompts.FlowChart
       );
+  },
+  meetingMinutesPrompt(params: MeetingMinutesParams): string {
+    const basePrompt =
+      'You are a professional meeting assistant. Create structured meeting minutes from the following transcript.';
+
+    if (params.style === 'custom' && params.customPrompt) {
+      return params.customPrompt;
+    }
+
+    switch (params.style) {
+      case 'executive':
+        return `${basePrompt}
+        
+Format as an executive summary with:
+- Meeting overview (2-3 sentences)
+- Key decisions made
+- Strategic action items with owners and deadlines
+- Next steps and follow-up meetings
+
+Use bullet points and keep it concise for senior leadership.`;
+
+      case 'detailed':
+        return `${basePrompt}
+        
+Format with comprehensive structure including:
+- Meeting details (date, time, attendees)
+- Agenda items discussed
+- Detailed discussion points for each topic
+- All decisions made with rationale
+- Complete action items with owners, deadlines, and dependencies
+- Open questions and concerns raised
+- Next meeting details
+
+Use clear headings, numbered lists, and detailed bullet points.`;
+
+      case 'standard':
+      default:
+        return `${basePrompt}
+        
+Format with standard structure:
+- Meeting summary
+- Main discussion points
+- Decisions made
+- Action items (owner, deadline)
+- Next steps
+
+Use clear headings and bullet points. Be concise but comprehensive.`;
+    }
   },
 };
 

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -65,6 +65,11 @@ export type DiagramParams = {
   diagramType?: string;
 };
 
+export type MeetingMinutesParams = {
+  style: 'standard' | 'executive' | 'detailed' | 'custom';
+  customPrompt?: string;
+};
+
 export type PromptListItem = {
   title: string;
   systemContext: string;
@@ -91,4 +96,5 @@ export interface Prompter {
   setTitlePrompt(params: SetTitleParams): string;
   promptList(t: TFunction): PromptList;
   diagramPrompt(params: DiagramParams): string;
+  meetingMinutesPrompt(params: MeetingMinutesParams): string;
 }


### PR DESCRIPTION
## Summary
- Add meeting minutes prompt templates supporting Standard, Executive, Detailed, and Custom formats
- Create `useMeetingMinutes` hook for state management and API integration with streaming support

## Test plan
- [ ] Prompt templates render correctly for each format
- [ ] Hook manages state correctly for style selection and auto-generation settings
- [ ] Streaming API integration works with real-time updates
- [ ] Error handling displays appropriate messages

🤖 Generated with [Claude Code](https://claude.ai/code)