### PR TITLE
fix: move copy buttons to top-right corner of panels

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -636,13 +636,14 @@ meetingMinutes:
   last_generated: Last generated {{time}}
   minutes_placeholder: Minutes will appear here after generation
   model: Model
+  next_generation_in: Next generation in
   record_transcribe: Record & Transcribe
   speech_recognition: Speech Recognition
   style: Minutes Style
   style_custom: Custom
-  style_detailed: Detailed
-  style_executive: Executive Summary
-  style_standard: Standard
+  style_faq: FAQ
+  style_newspaper: Newspaper
+  style_transcription: Transcription
   title: Meeting Minutes Generator
   transcript: Transcript
 model:

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -627,7 +627,6 @@ meetingMinutes:
   frequency_1min: Every 1 minute
   frequency_5min: Every 5 minutes
   generate: Generate
-  generate_minutes: Generate Minutes
   generate_minutes_header: Generate Minutes
   generated_minutes: Generated Minutes
   generating: Generating minutes...
@@ -636,7 +635,7 @@ meetingMinutes:
   last_generated: Last generated {{time}}
   minutes_placeholder: Minutes will appear here after generation
   model: Model
-  next_generation_in: Next generation in
+  next_generation_in: 'Next generation in : '
   record_transcribe: Record & Transcribe
   speech_recognition: Speech Recognition
   style: Minutes Style

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -554,13 +554,14 @@ meetingMinutes:
   last_generated: 最後の生成時刻 {{time}}
   minutes_placeholder: 生成後にここに議事録が表示されます
   model: モデル
+  next_generation_in: 次回生成まで
   record_transcribe: 録音・文字起こし
   speech_recognition: 音声認識
   style: 議事録スタイル
   style_custom: カスタム
-  style_detailed: 詳細
-  style_executive: エグゼクティブサマリー
-  style_standard: 標準
+  style_faq: 質疑応答
+  style_newspaper: 新聞
+  style_transcription: 文字起こし
   title: 議事録生成
   transcript: 文字起こし
 model:

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -545,8 +545,7 @@ meetingMinutes:
   frequency_1min: 1分ごと
   frequency_5min: 5分ごと
   generate: 生成
-  generate_minutes: 議事録を生成
-  generate_minutes_header: 議事録を生成
+  generate_minutes_header: 議事録生成
   generated_minutes: 生成された議事録
   generating: 議事録生成中...
   generation_error: 議事録の生成に失敗しました。再試行してください。
@@ -554,8 +553,8 @@ meetingMinutes:
   last_generated: 最後の生成時刻 {{time}}
   minutes_placeholder: 生成後にここに議事録が表示されます
   model: モデル
-  next_generation_in: 次回生成まで
-  record_transcribe: 録音・文字起こし
+  next_generation_in: '次回生成まで : '
+  record_transcribe: 音声認識
   speech_recognition: 音声認識
   style: 議事録スタイル
   style_custom: カスタム
@@ -575,7 +574,7 @@ navigation:
   flowChat: Flow チャット
   home: ホーム
   imageGeneration: 画像生成
-  meetingMinutes: 議事録
+  meetingMinutes: 議事録生成
   promptOptimization: プロンプト最適化
   ragChat: RAG チャット
   settings: 設定

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -547,6 +547,33 @@ language:
   ko: ภาษาเกาหลี
   th: ภาษาไทย
   zh: ภาษาจีน
+meetingMinutes:
+  auto_generate: สร้างอัตโนมัติ
+  custom_prompt: พรอมต์แบบกำหนดเอง
+  custom_prompt_placeholder: ป้อนพรอมต์แบบกำหนดเองสำหรับการสร้างรายงานการประชุม...
+  frequency: ความถี่ในการสร้าง
+  frequency_10min: ทุก 10 นาที
+  frequency_1min: ทุกนาที
+  frequency_5min: ทุก 5 นาที
+  generate: สร้าง
+  generate_minutes_header: สร้างรายงานการประชุม
+  generated_minutes: รายงานการประชุมที่สร้างแล้ว
+  generating: กำลังสร้างรายงานการประชุม...
+  generation_error: ไม่สามารถสร้างรายงานการประชุมได้ กรุณาลองอีกครั้ง
+  generation_success: สร้างรายงานการประชุมสำเร็จ
+  last_generated: สร้างล่าสุดเมื่อ {{time}}
+  minutes_placeholder: รายงานการประชุมจะปรากฏที่นี่หลังจากสร้าง
+  model: โมเดล
+  next_generation_in: 'สร้างครั้งถัดไปใน : '
+  record_transcribe: บันทึกและถอดความ
+  speech_recognition: การรู้จำเสียงพูด
+  style: รูปแบบรายงานการประชุม
+  style_custom: กำหนดเอง
+  style_faq: คำถามที่พบบ่อย
+  style_newspaper: หนังสือพิมพ์
+  style_transcription: การถอดความ
+  title: ตัวสร้างรายงานการประชุม
+  transcript: บันทึกการถอดความ
 model:
   parameters:
     reasoning: การให้เหตุผล
@@ -558,6 +585,7 @@ navigation:
   flowChat: Flow Chat
   home: Home (หน้าหลัก)
   imageGeneration: การสร้างภาพ
+  meetingMinutes: รายงานการประชุม
   promptOptimization: ปรับแต่ง Prompt ให้ตรงความต้องการ
   ragChat: RAG Chat
   settings: ตั้งค่า

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -534,6 +534,33 @@ language:
   ja: 日语
   ko: 韩语
   zh: 中文
+meetingMinutes:
+  auto_generate: 自动生成
+  custom_prompt: 自定义提示
+  custom_prompt_placeholder: 输入用于生成会议纪要的自定义提示...
+  frequency: 生成频率
+  frequency_10min: 每10分钟
+  frequency_1min: 每分钟
+  frequency_5min: 每5分钟
+  generate: 生成
+  generate_minutes_header: 生成会议纪要
+  generated_minutes: 已生成的会议纪要
+  generating: 正在生成会议纪要...
+  generation_error: 会议纪要生成失败。请重试。
+  generation_success: 会议纪要生成成功
+  last_generated: 最后生成时间 {{time}}
+  minutes_placeholder: 生成后会议纪要将显示在这里
+  model: 模型
+  next_generation_in: '下次生成时间 :'
+  record_transcribe: 录音和转录
+  speech_recognition: 语音识别
+  style: 会议纪要风格
+  style_custom: 自定义
+  style_faq: 常见问题
+  style_newspaper: 新闻报道
+  style_transcription: 转录
+  title: 会议纪要生成器
+  transcript: 转录文本
 model:
   parameters:
     reasoning: 推理
@@ -545,6 +572,7 @@ navigation:
   flowChat: Flow聊天
   home: 首页
   imageGeneration: 图像生成
+  meetingMinutes: 会议纪要
   promptOptimization: 提示优化
   ragChat: RAG聊天
   settings: 设置

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -224,7 +224,7 @@ const App: React.FC = () => {
       label: t('navigation.meetingMinutes'),
       to: '/meeting-minutes',
       icon: <PiFileText />,
-      display: 'tool' as const,
+      display: 'usecase' as const,
     },
     optimizePromptEnabled
       ? {

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -24,7 +24,8 @@ export const useMeetingMinutes = () => {
   const [lastGeneratedTime, setLastGeneratedTime] = useState<Date | null>(null);
   const [customPrompt, setCustomPrompt] = useState('');
   const [loading, setLoading] = useState(false);
-  const [autoGenerateSessionTimestamp, setAutoGenerateSessionTimestamp] = useState<number | null>(null);
+  const [autoGenerateSessionTimestamp, setAutoGenerateSessionTimestamp] =
+    useState<number | null>(null);
 
   const generateMinutes = useCallback(
     async (
@@ -109,7 +110,13 @@ export const useMeetingMinutes = () => {
         setLoading(false);
       }
     },
-    [minutesStyle, customPrompt, predictStream, textModels]
+    [
+      minutesStyle,
+      customPrompt,
+      predictStream,
+      textModels,
+      autoGenerateSessionTimestamp,
+    ]
   );
 
   const handleAutoGenerateToggle = useCallback((enabled: boolean) => {

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -155,7 +155,11 @@ const MeetingMinutesPage: React.FC = () => {
 
   // Watch for generation signal and trigger generation
   useEffect(() => {
-    if (shouldGenerateRef.current && autoGenerate && formattedOutput.trim() !== '') {
+    if (
+      shouldGenerateRef.current &&
+      autoGenerate &&
+      formattedOutput.trim() !== ''
+    ) {
       if (formattedOutput !== lastProcessedTranscript && !minutesLoading) {
         shouldGenerateRef.current = false; // Reset the flag
         generateMinutes(formattedOutput, modelId, (status) => {
@@ -169,7 +173,16 @@ const MeetingMinutesPage: React.FC = () => {
         shouldGenerateRef.current = false; // Reset even if we don't generate
       }
     }
-  }, [countdownSeconds]);
+  }, [
+    countdownSeconds,
+    autoGenerate,
+    formattedOutput,
+    lastProcessedTranscript,
+    minutesLoading,
+    generateMinutes,
+    modelId,
+    t,
+  ]);
 
   // Auto-generation countdown setup
   useEffect(() => {
@@ -191,7 +204,7 @@ const MeetingMinutesPage: React.FC = () => {
 
     // Set up countdown timer (updates every second)
     countdownIntervalRef.current = setInterval(() => {
-      setCountdownSeconds(prev => {
+      setCountdownSeconds((prev) => {
         const newValue = prev - 1;
         if (newValue <= 0) {
           shouldGenerateRef.current = true; // Signal generation should happen
@@ -206,10 +219,7 @@ const MeetingMinutesPage: React.FC = () => {
         clearInterval(countdownIntervalRef.current);
       }
     };
-  }, [
-    autoGenerate,
-    generationFrequency,
-  ]);
+  }, [autoGenerate, generationFrequency]);
 
   const disabledExec = useMemo(() => {
     return !file || loading || recording;
@@ -280,10 +290,7 @@ const MeetingMinutesPage: React.FC = () => {
   // Style change detection to trigger minutes regeneration
   useEffect(() => {
     // Only regenerate if style has changed, we have transcript content, and we're not in the initial render
-    if (
-      previousStyle !== minutesStyle &&
-      formattedOutput.trim() !== ''
-    ) {
+    if (previousStyle !== minutesStyle && formattedOutput.trim() !== '') {
       handleManualGeneration();
     }
 
@@ -495,11 +502,15 @@ const MeetingMinutesPage: React.FC = () => {
                       checked={autoGenerate}
                       onSwitch={setAutoGenerate}
                     />
+                    {/* eslint-disable @shopify/jsx-no-hardcoded-content */}
                     {autoGenerate && countdownSeconds > 0 && (
                       <div className="text-sm text-gray-600">
-                        {t('meetingMinutes.next_generation_in')}: {Math.floor(countdownSeconds / 60)}:{(countdownSeconds % 60).toString().padStart(2, '0')}
+                        {t('meetingMinutes.next_generation_in')}
+                        {Math.floor(countdownSeconds / 60)}:
+                        {(countdownSeconds % 60).toString().padStart(2, '0')}
                       </div>
                     )}
+                    {/* eslint-enable @shopify/jsx-no-hardcoded-content */}
                   </div>
                 </div>
                 {autoGenerate && (

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -86,7 +86,11 @@ const MeetingMinutesPage: React.FC = () => {
     setSpeakers,
   } = useMeetingMinutesState();
   const ref = useRef<HTMLInputElement>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const shouldGenerateRef = useRef<boolean>(false);
+
+  // Countdown state for auto-generation timer
+  const [countdownSeconds, setCountdownSeconds] = useState(0);
 
   // Model selection state
   const { modelIds: availableModels, modelDisplayName } = MODELS;
@@ -112,7 +116,7 @@ const MeetingMinutesPage: React.FC = () => {
 
   // Track previous style to detect changes
   const [previousStyle, setPreviousStyle] =
-    useState<typeof minutesStyle>('standard');
+    useState<typeof minutesStyle>('transcription');
 
   const speakerMapping = useMemo(() => {
     return Object.fromEntries(
@@ -149,74 +153,62 @@ const MeetingMinutesPage: React.FC = () => {
     }
   }, [setContent, transcriptMic]);
 
-  // Clean up interval on unmount
+  // Watch for generation signal and trigger generation
   useEffect(() => {
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+    if (shouldGenerateRef.current && autoGenerate && formattedOutput.trim() !== '') {
+      if (formattedOutput !== lastProcessedTranscript && !minutesLoading) {
+        shouldGenerateRef.current = false; // Reset the flag
+        generateMinutes(formattedOutput, modelId, (status) => {
+          if (status === 'success') {
+            toast.success(t('meetingMinutes.generation_success'));
+          } else if (status === 'error') {
+            toast.error(t('meetingMinutes.generation_error'));
+          }
+        });
+      } else {
+        shouldGenerateRef.current = false; // Reset even if we don't generate
       }
-    };
-  }, []);
+    }
+  }, [countdownSeconds]);
 
-  // Auto-generation logic with proper cleanup
+  // Auto-generation countdown setup
   useEffect(() => {
     // Clear existing interval
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+    if (countdownIntervalRef.current) {
+      clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
     }
 
-    if (!autoGenerate || generationFrequency <= 0 || !formattedOutput) return;
+    // Early return if auto-generate is disabled
+    if (!autoGenerate || generationFrequency <= 0) {
+      setCountdownSeconds(0);
+      return;
+    }
 
-    // Initial generation if needed
-    if (
-      formattedOutput !== lastProcessedTranscript &&
-      !minutesLoading &&
-      formattedOutput.trim() !== ''
-    ) {
-      generateMinutes(formattedOutput, modelId, (status) => {
-        if (status === 'success') {
-          toast.success(t('meetingMinutes.generation_success'));
-        } else if (status === 'error') {
-          toast.error(t('meetingMinutes.generation_error'));
+    // Initialize countdown
+    const totalSeconds = generationFrequency * 60;
+    setCountdownSeconds(totalSeconds);
+
+    // Set up countdown timer (updates every second)
+    countdownIntervalRef.current = setInterval(() => {
+      setCountdownSeconds(prev => {
+        const newValue = prev - 1;
+        if (newValue <= 0) {
+          shouldGenerateRef.current = true; // Signal generation should happen
+          return totalSeconds; // Reset countdown
         }
+        return newValue;
       });
-    }
-
-    // Set up interval for periodic generation
-    intervalRef.current = setInterval(
-      () => {
-        if (
-          formattedOutput !== lastProcessedTranscript &&
-          !minutesLoading &&
-          formattedOutput.trim() !== ''
-        ) {
-          generateMinutes(formattedOutput, modelId, (status) => {
-            if (status === 'success') {
-              toast.success(t('meetingMinutes.generation_success'));
-            } else if (status === 'error') {
-              toast.error(t('meetingMinutes.generation_error'));
-            }
-          });
-        }
-      },
-      generationFrequency * 60 * 1000
-    ); // Convert minutes to milliseconds
+    }, 1000);
 
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      if (countdownIntervalRef.current) {
+        clearInterval(countdownIntervalRef.current);
       }
     };
   }, [
     autoGenerate,
     generationFrequency,
-    formattedOutput,
-    lastProcessedTranscript,
-    minutesLoading,
-    modelId,
-    generateMinutes,
-    t,
   ]);
 
   const disabledExec = useMemo(() => {
@@ -290,8 +282,7 @@ const MeetingMinutesPage: React.FC = () => {
     // Only regenerate if style has changed, we have transcript content, and we're not in the initial render
     if (
       previousStyle !== minutesStyle &&
-      formattedOutput.trim() !== '' &&
-      previousStyle !== 'standard'
+      formattedOutput.trim() !== ''
     ) {
       handleManualGeneration();
     }
@@ -448,16 +439,16 @@ const MeetingMinutesPage: React.FC = () => {
                     }
                     options={[
                       {
-                        value: 'standard',
-                        label: t('meetingMinutes.style_standard'),
+                        value: 'transcription',
+                        label: t('meetingMinutes.style_transcription'),
                       },
                       {
-                        value: 'executive',
-                        label: t('meetingMinutes.style_executive'),
+                        value: 'newspaper',
+                        label: t('meetingMinutes.style_newspaper'),
                       },
                       {
-                        value: 'detailed',
-                        label: t('meetingMinutes.style_detailed'),
+                        value: 'faq',
+                        label: t('meetingMinutes.style_faq'),
                       },
                       {
                         value: 'custom',
@@ -498,11 +489,18 @@ const MeetingMinutesPage: React.FC = () => {
 
                 {/* Auto-generation controls */}
                 <div className="mb-4">
-                  <Switch
-                    label={t('meetingMinutes.auto_generate')}
-                    checked={autoGenerate}
-                    onSwitch={setAutoGenerate}
-                  />
+                  <div className="flex items-center justify-between">
+                    <Switch
+                      label={t('meetingMinutes.auto_generate')}
+                      checked={autoGenerate}
+                      onSwitch={setAutoGenerate}
+                    />
+                    {autoGenerate && countdownSeconds > 0 && (
+                      <div className="text-sm text-gray-600">
+                        {t('meetingMinutes.next_generation_in')}: {Math.floor(countdownSeconds / 60)}:{(countdownSeconds % 60).toString().padStart(2, '0')}
+                      </div>
+                    )}
+                  </div>
                 </div>
                 {autoGenerate && (
                   <div className="mb-4">
@@ -549,8 +547,16 @@ const MeetingMinutesPage: React.FC = () => {
           <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
             {/* Transcript Panel */}
             <div className="rounded border border-black/30 p-1.5">
-              <div className="mb-2 font-bold">
-                {t('meetingMinutes.transcript')}
+              <div className="mb-2 flex items-center justify-between">
+                <div className="font-bold">
+                  {t('meetingMinutes.transcript')}
+                </div>
+                {formattedOutput.trim() !== '' && (
+                  <ButtonCopy
+                    text={formattedOutput}
+                    interUseCasesKey="transcript"
+                  />
+                )}
               </div>
               {content.length > 0 && (
                 <div>
@@ -575,26 +581,28 @@ const MeetingMinutesPage: React.FC = () => {
               {loading && (
                 <div className="border-aws-sky size-5 animate-spin rounded-full border-4 border-t-transparent"></div>
               )}
-              <div className="mt-2 flex w-full justify-end">
-                <ButtonCopy
-                  text={formattedOutput}
-                  interUseCasesKey="transcript"
-                />
-              </div>
             </div>
 
             {/* Generated Minutes Panel */}
             <div className="rounded border border-black/30 p-1.5">
               <div className="mb-2 flex items-center justify-between">
-                <div className="font-bold">
-                  {t('meetingMinutes.generated_minutes')}
-                </div>
-                {lastGeneratedTime && (
-                  <div className="text-sm text-gray-500">
-                    {t('meetingMinutes.last_generated', {
-                      time: lastGeneratedTime.toLocaleTimeString(),
-                    })}
+                <div className="flex items-center gap-2">
+                  <div className="font-bold">
+                    {t('meetingMinutes.generated_minutes')}
                   </div>
+                  {lastGeneratedTime && (
+                    <div className="text-sm text-gray-500">
+                      {t('meetingMinutes.last_generated', {
+                        time: lastGeneratedTime.toLocaleTimeString(),
+                      })}
+                    </div>
+                  )}
+                </div>
+                {generatedMinutes.trim() !== '' && (
+                  <ButtonCopy
+                    text={generatedMinutes}
+                    interUseCasesKey="minutes"
+                  />
                 )}
               </div>
               <Markdown>{generatedMinutes}</Markdown>
@@ -611,12 +619,6 @@ const MeetingMinutesPage: React.FC = () => {
                   </span>
                 </div>
               )}
-              <div className="mt-2 flex w-full justify-end gap-2">
-                <ButtonCopy
-                  text={generatedMinutes}
-                  interUseCasesKey="minutes"
-                />
-              </div>
             </div>
           </div>
         </Card>

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -558,51 +558,20 @@ Output only the selected chart type from the <Choice> list, with an exact match,
       );
   },
   meetingMinutesPrompt(params: MeetingMinutesParams): string {
-    const basePrompt =
-      'You are a professional meeting assistant. Create structured meeting minutes from the following transcript.';
-
     if (params.style === 'custom' && params.customPrompt) {
       return params.customPrompt;
     }
 
     switch (params.style) {
-      case 'executive':
-        return `${basePrompt}
-        
-Format as an executive summary with:
-- Meeting overview (2-3 sentences)
-- Key decisions made
-- Strategic action items with owners and deadlines
-- Next steps and follow-up meetings
+      case 'newspaper':
+        return `As a professional journalist. You will receive transcribed text from reporters and craft an article while preserving as much of the original content volume as possible to deliver comprehensive information to your audience. For your audience, you must write the article in received text language.`;
 
-Use bullet points and keep it concise for senior leadership.`;
+      case 'faq':
+        return `As a professional assistant, please identify the conversation topic and write an abstract summarizing the theme along with question-and-answer pairs that preserve the original information content as much as possible. For your boss, you must write in received conversation language.`;
 
-      case 'detailed':
-        return `${basePrompt}
-        
-Format with comprehensive structure including:
-- Meeting details (date, time, attendees)
-- Agenda items discussed
-- Detailed discussion points for each topic
-- All decisions made with rationale
-- Complete action items with owners, deadlines, and dependencies
-- Open questions and concerns raised
-- Next meeting details
-
-Use clear headings, numbered lists, and detailed bullet points.`;
-
-      case 'standard':
+      case 'transcription':
       default:
-        return `${basePrompt}
-        
-Format with standard structure:
-- Meeting summary
-- Main discussion points
-- Decisions made
-- Action items (owner, deadline)
-- Next steps
-
-Use clear headings and bullet points. Be concise but comprehensive.`;
+        return `As a professional translator, please correct filler words and misrecognition in received transcribed text. Please add paragraph breaks if you detect obvious topic changes, and if you find important statements related to the topic, please format them in bold style. For speakers, you must transcribe in received text language.`;
     }
   },
 };

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -66,7 +66,7 @@ export type DiagramParams = {
 };
 
 export type MeetingMinutesParams = {
-  style: 'standard' | 'executive' | 'detailed' | 'custom';
+  style: 'transcription' | 'newspaper' | 'faq' | 'custom';
   customPrompt?: string;
 };
 


### PR DESCRIPTION
## Summary
- Move copy buttons from bottom to header area in both transcript and generated minutes panels
- Copy buttons now stay in fixed position at the top-right corner and don't move as content grows
- Only display copy buttons when there is content to copy

## Test plan
- [x] Verify copy buttons appear in the top-right corner of both panels
- [x] Verify copy buttons only appear when there is content
- [x] Test that buttons remain in fixed position as transcript grows
- [x] Test copy functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)